### PR TITLE
Removed file-saver library

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@angular/platform-browser-dynamic": "^4.3.6",
     "@angular/router": "^4.3.6",
     "core-js": "^2.5.0",
-    "file-saver": "^1.3.3",
     "rxjs": "^5.4.3",
     "xlsx": "^0.11.3",
     "zone.js": "^0.8.17"

--- a/src/app/excel.service.ts
+++ b/src/app/excel.service.ts
@@ -1,5 +1,4 @@
 import { Injectable } from '@angular/core';
-import * as FileSaver from 'file-saver';
 import * as XLSX from 'xlsx';
 
 const EXCEL_TYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet;charset=UTF-8';
@@ -13,15 +12,6 @@ export class ExcelService {
   public exportAsExcelFile(json: any[], excelFileName: string): void {
     const worksheet: XLSX.WorkSheet = XLSX.utils.json_to_sheet(json);
     const workbook: XLSX.WorkBook = { Sheets: { 'data': worksheet }, SheetNames: ['data'] };
-    const excelBuffer: any = XLSX.write(workbook, { bookType: 'xlsx', type: 'buffer' });
-    this.saveAsExcelFile(excelBuffer, excelFileName);
+    XLSX.writeFile(workbook, excelFileName + '_export_' + new Date().getTime() + EXCEL_EXTENSION);
   }
-
-  private saveAsExcelFile(buffer: any, fileName: string): void {
-    const data: Blob = new Blob([buffer], {
-      type: EXCEL_TYPE
-    });
-    FileSaver.saveAs(data, fileName + '_export_' + new Date().getTime() + EXCEL_EXTENSION);
-  }
-
 }


### PR DESCRIPTION
Hi, in order to make this great service lighter, I removed file-saver as its only function here was to download the generated Excel, which can be done by xlsx package itself when using `XLSX.writeFile()` method.

Hope this helps.

Thanks.